### PR TITLE
fix: update actions/cache from v3 to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}


### PR DESCRIPTION
## Summary

- Updates `actions/cache` from `v3` to `v4` in `.github/workflows/tests.yml`
- Fixes the `brew test-bot` CI failure on PR #133 where `actionlint` flagged `actions/cache@v3` as too old to run on GitHub Actions

## Test plan

- [ ] Verify `brew test-bot` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)