### PR TITLE
fix: repair the tap release pipeline and the specdown formula

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,26 +6,34 @@ on:
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      issues: read
+      pull-requests: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@main
 
+      # test-bot bottles non-core taps with a GitHub Releases root_url, so pr-upload
+      # needs no GitHub Packages configuration -- only contents: write.
       - name: Pull bottles
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
-          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
-          HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@main
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: main
 
       - name: Delete branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,36 +8,35 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os:
-          - ubuntu-24.04
-          - ubuntu-24.04-arm
-          - macos-26-intel
-          - macos-26
+        include:
+          - os: macos-26
+          - os: macos-26-intel
+          - os: ubuntu-latest
+            container: ghcr.io/homebrew/brew:main
+          - os: ubuntu-24.04-arm
+            container: ghcr.io/homebrew/brew:main
+    # Without this the container image ends up in the check name, which Mergify matches on.
+    name: test-bot (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Homebrew Bundler RubyGems
-        id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-${{ runner.arch }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-rubygems-
-
-      - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: brew install-bundler-gems
-
-      - name: Install bubblewrap (Linux sandbox requirement)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y bubblewrap
-          sudo sysctl -w kernel.unprivileged_userns_clone=1 || true
-          sudo sysctl -w user.max_user_namespaces=28633 || true
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.os }}-rubygems-
 
       - run: brew test-bot --only-cleanup-before
 
@@ -48,9 +47,21 @@ jobs:
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'
 
+      # test-bot reports a failed install as a "skipped" formula, and stays green, when
+      # the formula has no bottle for the version under test -- which is always true of
+      # a version bump. Install and test it ourselves so breakage is always caught.
+      - name: Verify the formula installs and passes its test
+        if: github.event_name == 'pull_request'
+        env:
+          # This tap is the repository under test, so loading it needs no confirmation.
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
+        run: |
+          brew install --formula --verbose "$GITHUB_REPOSITORY/specdown"
+          brew test --verbose "$GITHUB_REPOSITORY/specdown"
+
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: bottles_${{matrix.os}}
+          name: bottles_${{ matrix.os }}
           path: '*.bottle.*'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# `brew test-bot` scratch output
+bottle_output.txt
+linkage_output.txt
+skipped_or_failed_formulae-*.txt
+*.bottle.*

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
     merge_conditions:
-      - status-success=test-bot (ubuntu-24.04)
+      - status-success=test-bot (ubuntu-latest)
       - status-success=test-bot (ubuntu-24.04-arm)
       - status-success=test-bot (macos-26-intel)
       - status-success=test-bot (macos-26)
@@ -9,7 +9,7 @@ queue_rules:
 pull_request_rules:
   - name: automatic rebase for releases
     conditions:
-      - status-success=test-bot (ubuntu-24.04)
+      - status-success=test-bot (ubuntu-latest)
       - status-success=test-bot (ubuntu-24.04-arm)
       - status-success=test-bot (macos-26-intel)
       - status-success=test-bot (macos-26)

--- a/Formula/specdown.rb
+++ b/Formula/specdown.rb
@@ -2,64 +2,53 @@ class Specdown < Formula
   desc "Use your markdown documentation as tests"
   homepage "https://github.com/specdown/specdown"
   license "Apache-2.0"
-  depends_on "help2man" => :build
+  version_scheme 1
 
   on_macos do
     on_arm do
-      url "https://github.com/specdown/specdown/releases/download/v1.3.3/specdown-aarch64-apple-darwin"
-      sha256 "bd6bfc3370a9c859c097921aa15d855988920b922d41373aee120542ed168a9a"
+      url "https://github.com/specdown/specdown/releases/download/v1.6.1/specdown-aarch64-apple-darwin"
+      sha256 "284a438ef56e1d1819feb6c66a8b1e32b717c4e06382aca7b2a82860365025b4"
     end
     on_intel do
-      url "https://github.com/specdown/specdown/releases/download/v1.3.3/specdown-x86_64-apple-darwin"
-      sha256 "707a8fdc56159aaf1892592d2e7fee90e01560f8e318e0d3eae03188a7785158"
+      url "https://github.com/specdown/specdown/releases/download/v1.6.1/specdown-x86_64-apple-darwin"
+      sha256 "fd8da91737ff44aebc70e3d150c14651b71939c14f37e55ae27866de669879cb"
+      version "1.6.1"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/specdown/specdown/releases/download/v1.3.3/specdown-x86_64-unknown-linux-gnu"
-      sha256 "8c91a5e19d60379d6322002708b348942037a375e7232759e066fcebc58f2018"
+      url "https://github.com/specdown/specdown/releases/download/v1.6.1/specdown-x86_64-unknown-linux-gnu"
+      sha256 "a280ceacbe64dc5edd3a53f2046855df4f35ec0ac12fa6b038979c6195fbbcd6"
+      version "1.6.1"
     end
     on_arm do
-      url "https://github.com/specdown/specdown/releases/download/v1.3.3/specdown-aarch64-unknown-linux-gnu"
-      sha256 "c30c535b477743cac8400b8ff556d34f7b939deb45e70bc08cf6bd5e5f774b33"
+      url "https://github.com/specdown/specdown/releases/download/v1.6.1/specdown-aarch64-unknown-linux-gnu"
+      sha256 "fb9674d18541a334ed488729cfeace3f4f2b534685ead553bdb2fe883472c3a7"
     end
   end
 
   resource("testdata") do
-    url "https://raw.githubusercontent.com/specdown/specdown/v1.3.3/README.md"
+    url "https://raw.githubusercontent.com/specdown/specdown/v1.6.1/README.md"
     sha256 "b4a0f54551331989fc3f4776188dfcbb901da2e2ff511cd801ba6d30fb662e8c"
   end
 
   def install
-    if OS.mac?
-      if Hardware::CPU.arm?
-        bin.install "specdown-aarch64-apple-darwin" => "specdown"
-      elsif Hardware::CPU.intel?
-        bin.install "specdown-x86_64-apple-darwin" => "specdown"
-      end
-    elsif OS.linux?
-      if Hardware::CPU.intel?
-        bin.install "specdown-x86_64-unknown-linux-gnu" => "specdown"
-      elsif Hardware::CPU.arm?
-        bin.install "specdown-aarch64-unknown-linux-gnu" => "specdown"
-      end
+    binary = if OS.mac?
+      Hardware::CPU.arm? ? "specdown-aarch64-apple-darwin" : "specdown-x86_64-apple-darwin"
+    else
+      Hardware::CPU.arm? ? "specdown-aarch64-unknown-linux-gnu" : "specdown-x86_64-unknown-linux-gnu"
     end
 
-    generate_completions_from_executable(bin/"specdown", "completion", shells: [
-      :bash,
-      :fish,
-      :zsh,
-    ])
+    chmod 0755, binary
+    bin.install binary => "specdown"
 
-    # Man pages
-    output = Utils.safe_popen_read("help2man", "#{bin}/specdown")
-    (man1/"specdown.1").write output
+    generate_completions_from_executable(bin/"specdown", "completion")
   end
 
   test do
-    system "#{bin}/specdown", "-h"
-    system "#{bin}/specdown", "-V"
+    system bin/"specdown", "-h"
+    system bin/"specdown", "-V"
 
     resource("testdata").stage do
       assert_match "5 functions run (5 succeeded / 0 failed)", shell_output("#{bin}/specdown run README.md")


### PR DESCRIPTION
All 12 open release PRs (#142 v1.3.4 → #153 v1.6.1) are red, and the tap has been shipping a formula that **cannot install** since v1.3.3 was merged in May. `brew install specdown/repo/specdown` is broken for users today.

This PR fixes the formula and the pipeline together, and bumps to v1.6.1. The upstream template fix is specdown/specdown#609 — without it, the next release regenerates `Formula/specdown.rb` and reintroduces every bug here.

## The formula

**The installed binary is not executable.** `bin.install` is a plain `FileUtils.mv` (`extend/pathname.rb:496`) and does not chmod, despite what the Formula Cookbook implies. The release assets are bare binaries that download as `0644`, so every CI run since v1.3.3 contains `brew: exec failed (EACCES): .../bin/specdown`, raised when `generate_completions_from_executable` tries to run it. Fixed with `chmod 0755` before install.

**The version was wrong on x86_64.** With no `version` stanza Homebrew scans it from the URL, and the scanner trips over the `_64` in `x86_64`:

| asset | scanned version |
|---|---|
| `specdown-aarch64-apple-darwin` | `1.6.1` |
| `specdown-x86_64-apple-darwin` | `64-apple-darwin` |
| `specdown-x86_64-unknown-linux-gnu` | `64-unknown-linux-gnu` |
| `specdown-aarch64-unknown-linux-gnu` | `1.6.1` |

That is why Linux installed into `Cellar/specdown/64-unknown-linux-gnu`. `version` is declared in the two `on_intel` blocks rather than at the top level, because on arm the URL scan already works and `brew audit` rejects a top-level version as redundant.

**`version_scheme 1`.** Those bogus versions compare *greater* than any real version (`64` > `1`), so `brew upgrade` would treat `1.6.1` as a downgrade and never move existing x86_64 Linux users off the broken build. A version_scheme bump is Homebrew's mechanism for this (`formula.rb:3580`), and it is also what satisfies `brew audit --git`'s "version should not decrease".

**`brew style`** now rejects the default `shells:` argument (`FormulaAudit/RedundantGenerateCompletionsShells`). This is the visible failure on every open PR. Since `--only-tap-syntax` lints the whole tap, it had to be fixed here rather than in a follow-up.

**Dropped the `help2man` build dependency**, and with it the man page. `brew test-bot` only builds a bottle when every build dependency already has a bottle for the runner's exact OS (`build_bottle?`, `lib/tests/formulae.rb:311`). help2man publishes no Intel macOS bottle newer than `sonoma`, and the only Intel macOS runners GitHub offers are `macos-15-intel` and `macos-26-intel` — so no Intel macOS bottle for specdown could be produced at all, and test-bot silently skipped the formula there instead of installing it. The formula now has no dependencies and bottles on every platform.

## Why CI never caught any of this

`brew test-bot --only-formulae` cannot be relied on to fail on a broken formula:

- `ignore_failures = ... && !bottled_on_current_version && !new_formula` (`lib/tests/formulae.rb:412`). A version bump never carries a bottle for the version under test, so a failed install is downgraded to `skipped` and the job goes green.
- `build_bottle?` skips the formula outright, without installing it, when a build dependency lacks an exact-OS bottle (the help2man case above).

So the job stayed green, no bottle was built, no artifact was uploaded, and `brew pr-pull` then died with `No artifacts with the pattern bottles{,_*} were found!`. That is why #142–#146 stalled at publish while #147+ stalled earlier at style.

This PR adds an explicit `brew install` + `brew test` step, which fails on every platform regardless of what test-bot decides to skip.

## Pipeline

- `Homebrew/actions/*@master` → `@main` (deprecated, becomes a hard error).
- `actions/cache@v5`, `actions/upload-artifact@v7` (v4 pins Node 20).
- `publish.yml` off the retired `ubuntu-22.04`; explicit `permissions:` on both workflows.
- Linux runs in `ghcr.io/homebrew/brew:main` (multi-arch), removing the manual bubblewrap/sysctl workaround.
- Dropped the inert `HOMEBREW_GITHUB_PACKAGES_*` vars: test-bot defaults non-core taps to a GitHub Releases `root_url` (`formulae.rb:246`), which is where the last real bottle at 1.2.98 went, and where the 1.6.1 bottles now go.
- Job names pinned via `name:` so adding `container:` doesn't rename the checks Mergify waits on; `.mergify.yml` updated to match.

## Verification

`brew style`, `brew audit` and `brew readall --aliases --os=all --arch=all` pass against a scratch tap, and all four os/arch combinations resolve to `1.6.1` with `version_scheme 1` and no dependencies. CI exercises a real `brew install` + `brew test` on each platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)